### PR TITLE
Add -a flag to calculate total loudness values

### DIFF
--- a/ebu-scan
+++ b/ebu-scan
@@ -28,14 +28,32 @@ then
 fi
 done
 
+TEMPDIR=$(mktemp -d)
+
 if [ $# -eq 0 ]
 then
 	echo "Usage: ebu-scan <input files>"
 	exit
+elif [ "$1" = "-a" ] && [ $# -eq 1 ]
+then
+	echo "Please add some audio files"
+	exit	 
 elif [ $NUMARG -eq 0 ]
 then
 	echo "No compatible audio files present"
 	exit
+elif [ "$1" = "-a" ]
+then
+	shift
+	echo "Treating audio files as album..."
+	sleep 1
+	for file in "$@" ; do 
+	if [ "${file##*.}" == wav ] || [ "${file##*.}" == aif ] || [ "${file##*.}" == aiff ] || [ "${file##*.}" == flac ] || [ "${file##*.}" == ogg ] || [ "${file##*.}" == opus ] || [ "${file##*.}" == mp3 ] || [ "${file##*.}" == wv ];
+	then	
+		echo -e "file " "'"$(realpath "$file")"'" >> $TEMPDIR/audiofiles.txt
+	fi
+	done
+	ffmpeg -f concat -safe 0 -i $TEMPDIR/audiofiles.txt -af ebur128=peak=true -ar 4410 -f null - > $TEMPDIR/album.txt 2>&1 &
 else
 	:
 fi
@@ -44,8 +62,7 @@ fi
 path=$(realpath "$1")
 dirname="${path%/*}"
 
-# Create temp dir and audio files
-TEMPDIR=$(mktemp -d)
+# Create header for analysis file
 echo "File|True Peak|Integrated|Short-term|Momentary|LRA" > "$TEMPDIR/tempanalysis"
 echo "|(dBTP)|(LUFS)|(LUFS)|(LUFS)|(LU)" >> "$TEMPDIR/tempanalysis"
 touch "$TEMPDIR/skipped.txt"
@@ -70,8 +87,8 @@ then
 	ffmpeg -i "$file" -af ebur128=peak=true -ar 4410 -f null - > "$TEMPDIR/la.txt" 2>&1
 	INT=$(awk '/I:   / {print $2}' "$TEMPDIR/la.txt") 
 	PEAK=$(awk '/Peak:/ {print $2}' "$TEMPDIR/la.txt") 
-	SHORT=$(grep -o 'S: .*' "$TEMPDIR/la.txt" | awk '{print $2}' | sort -rn | head -n 1) 
-	MOM=$(grep -o 'M: .*' "$TEMPDIR/la.txt" | awk '{print $2}' | sort -rn | head -n 1)
+	SHORT=$(grep -o 'S: .*' "$TEMPDIR/la.txt" | awk '{print $2}' | sort -rg | head -n 1) 
+	MOM=$(grep -o 'M: .*' "$TEMPDIR/la.txt" | awk '{print $2}' | sort -rg | head -n 1)
 	LRA=$(awk '/LRA:     / {print $2}' "$TEMPDIR/la.txt")
 	echo "$FILENAME|$PEAK|$INT|$SHORT|$MOM|$LRA" >> "$TEMPDIR/tempanalysis"
 	echo -ne 'Analyzing...'$NUM'/'$NUMARG'\r'  
@@ -85,6 +102,19 @@ else
 :
 fi
 done
+
+wait
+
+if [ -f "$TEMPDIR/album.txt" ]
+then
+	AINT=$(awk '/I:   / {print $2}' "$TEMPDIR/album.txt") 
+	APEAK=$(awk '/Peak:/ {print $2}' "$TEMPDIR/album.txt") 
+	ASHORT=$(grep -o 'S: .*' "$TEMPDIR/album.txt" | awk '{print $2}' | sort -rg | head -n 1) 
+	AMOM=$(grep -o 'M: .*' "$TEMPDIR/album.txt" | awk '{print $2}' | sort -rg | head -n 1)
+	ALRA=$(awk '/LRA:     / {print $2}' "$TEMPDIR/album.txt")
+	echo >> "$TEMPDIR/tempanalysis"
+	echo "Album|$APEAK|$AINT|$ASHORT|$AMOM|$ALRA" >> "$TEMPDIR/tempanalysis"
+fi
 
 	#Format analysis data and print	
 	echo


### PR DESCRIPTION
If -a flag is added, all the files are treated as belonging to the same album and in addition to individual analysis, the whole album values are also returned. Most probably tracks should be all in the same format with same channel count.